### PR TITLE
Fixing issue with lodash merge method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -612,7 +612,7 @@
         "gtoken": "1.2.2",
         "jws": "3.1.4",
         "lodash.isstring": "4.0.1",
-        "lodash.merge": "4.6.0",
+        "lodash.merge": "4.6.2",
         "request": "2.83.0"
       }
     },
@@ -869,8 +869,8 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "long": {


### PR DESCRIPTION
Upgraded from 4.6.0 to 4.6.2, fix for issue #79 which has critical security vulnerability.