### PR TITLE
lodash library upgrade from patch 4 to 15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -859,8 +859,8 @@
       "optional": true
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.isstring": {
@@ -1311,7 +1311,7 @@
         "dottie": "2.0.0",
         "generic-pool": "3.1.8",
         "inflection": "1.12.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.15",
         "moment": "2.18.1",
         "moment-timezone": "0.5.13",
         "retry-as-promised": "2.3.1",


### PR DESCRIPTION
Addresses a critical security alert referenced in issue #81.