### PR TITLE
added false for use aliases sequelize

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -5,7 +5,8 @@
     "database": "pedalhead",
     "host": "localhost",
     "dialect": "mysql",
-    "port": 8889
+    "port": 8889,
+    "operatorsAliases": "false"
   },
   "production": {
     "username": "ommac7fddq2778us",


### PR DESCRIPTION
Warning message is bug, if your not using aliases in project. I added "operatorsAliases": "false" to remove to warning...

issue #101 